### PR TITLE
[#2] Add Springboot auto-config for tracing components

### DIFF
--- a/tracing-spring-boot-autoconfigure/pom.xml
+++ b/tracing-spring-boot-autoconfigure/pom.xml
@@ -34,11 +34,11 @@
 
     <dependencies>
 
-        <!--<dependency>-->
-            <!--<groupId>org.axonframework.extensions.tracing</groupId>-->
-            <!--<artifactId>axon-tracing</artifactId>-->
-            <!--<version>${project.version}</version>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>org.axonframework.extensions.tracing</groupId>
+            <artifactId>axon-tracing</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.axonframework</groupId>

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
@@ -19,16 +19,19 @@ import io.opentracing.Tracer;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
-import org.axonframework.extensions.tracing.OpenTraceDispatchInterceptor;
-import org.axonframework.extensions.tracing.OpenTraceHandlerInterceptor;
-import org.axonframework.extensions.tracing.TracingCommandGateway;
-import org.axonframework.extensions.tracing.TracingQueryGateway;
+import org.axonframework.config.EventProcessingConfiguration;
+import org.axonframework.config.EventProcessingConfigurer;
+import org.axonframework.extensions.tracing.*;
+import org.axonframework.messaging.correlation.CorrelationDataProvider;
+import org.axonframework.messaging.correlation.MessageOriginProvider;
 import org.axonframework.queryhandling.DefaultQueryGateway;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.springboot.autoconfig.EventProcessingAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -77,6 +80,17 @@ public class TracingAutoConfiguration {
                 .commandBus(commandBus)
                 .dispatchInterceptors(openTraceDispatchInterceptor);
         return new TracingCommandGateway(builder, tracer);
+    }
+
+    @Bean
+    public CorrelationDataProvider tracingProvider(Tracer tracer) {
+        return new TracingProvider(tracer);
+    }
+
+
+    @Autowired
+    public void configureEventHandler(EventProcessingConfigurer config, OpenTraceHandlerInterceptor openTraceHandlerInterceptor){
+        config.registerDefaultHandlerInterceptor((configuration, name) -> openTraceHandlerInterceptor);
     }
 
 }

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.tracing.autoconfig;
+
+import io.opentracing.Tracer;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.extensions.tracing.OpenTraceDispatchInterceptor;
+import org.axonframework.extensions.tracing.OpenTraceHandlerInterceptor;
+import org.axonframework.extensions.tracing.TracingCommandGateway;
+import org.axonframework.extensions.tracing.TracingQueryGateway;
+import org.axonframework.queryhandling.DefaultQueryGateway;
+import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.springboot.autoconfig.EventProcessingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+
+@Configuration
+@AutoConfigureAfter(EventProcessingAutoConfiguration.class)
+public class TracingAutoConfiguration {
+
+    @Bean
+    public OpenTraceDispatchInterceptor traceDispatchInterceptor(Tracer tracer) {
+        return new OpenTraceDispatchInterceptor(tracer);
+    }
+
+    @Bean
+    public OpenTraceHandlerInterceptor traceHandlerInterceptor(Tracer tracer) {
+        return new OpenTraceHandlerInterceptor(tracer);
+    }
+
+    @Bean
+    @Primary
+    public QueryGateway queryGateway(QueryBus queryBus, OpenTraceDispatchInterceptor openTraceDispatchInterceptor, OpenTraceHandlerInterceptor openTraceHandlerInterceptor, Tracer tracer) {
+
+        queryBus.registerHandlerInterceptor(openTraceHandlerInterceptor);
+
+        DefaultQueryGateway.Builder builder = DefaultQueryGateway.builder()
+                .queryBus(queryBus)
+                .dispatchInterceptors(openTraceDispatchInterceptor);
+
+        return new TracingQueryGateway(builder, tracer);
+    }
+
+    @Bean
+    @Primary
+    public CommandGateway commandGateway(CommandBus commandBus, OpenTraceDispatchInterceptor openTraceDispatchInterceptor, OpenTraceHandlerInterceptor openTraceHandlerInterceptor, Tracer tracer) {
+
+        commandBus.registerHandlerInterceptor(openTraceHandlerInterceptor);
+
+        DefaultCommandGateway.Builder builder = DefaultCommandGateway.builder()
+                .commandBus(commandBus)
+                .dispatchInterceptors(openTraceDispatchInterceptor);
+        return new TracingCommandGateway(builder, tracer);
+    }
+
+}

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.extensions.tracing.autoconfig;
 
 import io.opentracing.Tracer;
@@ -44,13 +28,20 @@ import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.springboot.autoconfig.EventProcessingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
-
+/**
+ * Auto configure a tracing capabilities.
+ *
+ * @author Christophe Bouhier
+ * @since 4.0
+ */
 @Configuration
 @AutoConfigureAfter(EventProcessingAutoConfiguration.class)
+@ConditionalOnClass(io.opentracing.Tracer.class)
 public class TracingAutoConfiguration {
 
     @Bean

--- a/tracing-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/tracing-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.axonframework.extensions.tracing.autoconfig.TracingAutoConfiguration

--- a/tracing-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/tracing/autoconfig/AxonAutoConfigurationWithTracingTest.java
+++ b/tracing-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/tracing/autoconfig/AxonAutoConfigurationWithTracingTest.java
@@ -1,0 +1,70 @@
+package org.axonframework.extensions.tracing.autoconfig;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.extensions.tracing.OpenTraceDispatchInterceptor;
+import org.axonframework.extensions.tracing.OpenTraceHandlerInterceptor;
+import org.axonframework.extensions.tracing.TracingCommandGateway;
+import org.axonframework.extensions.tracing.TracingQueryGateway;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+@EnableAutoConfiguration(exclude = {
+        JmxAutoConfiguration.class,
+        WebClientAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        DataSourceAutoConfiguration.class,
+        AxonServerAutoConfiguration.class})
+@RunWith(SpringRunner.class)
+public class AxonAutoConfigurationWithTracingTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private QueryGateway queryGateway;
+
+    @Autowired
+    private OpenTraceHandlerInterceptor openTraceHandlerInterceptor;
+
+    @Autowired
+    private OpenTraceDispatchInterceptor openTraceDispatchInterceptor;
+
+    @Autowired
+    private CommandGateway commandGateway;
+
+    @Test
+    public void testContextInitialization() {
+
+        assertNotNull(applicationContext);
+
+        assertThat(openTraceDispatchInterceptor, notNullValue());
+
+        assertThat(openTraceHandlerInterceptor, notNullValue());
+
+        assertThat(queryGateway, instanceOf(TracingQueryGateway.class));
+
+        // How TODO Assertion of registered interceptors?
+
+        assertThat(commandGateway, instanceOf(TracingCommandGateway.class));
+
+        // How TODO Assertion of registered interceptors?
+
+
+
+    }
+}

--- a/tracing-spring-boot-autoconfigure/src/test/resources/log4j.properties
+++ b/tracing-spring-boot-autoconfigure/src/test/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2010-2017. Axon Framework
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.appender.Stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.Stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.Stdout.layout.conversionPattern=%d [%t] %-5p %-30.30c{1} %x - %m%n
+
+log4j.rootLogger=INFO,Stdout
+
+log4j.logger.org.axonframework=INFO

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -52,16 +52,6 @@
             <scope>test</scope>
         </dependency>
 
-
-
-        <!-- THIS IS THE FULL FLEDGE STARTER WITH JAEGER WIRING -->
-        <!--<dependency>-->
-            <!--<groupId>io.opentracing.contrib</groupId>-->
-            <!--<artifactId>opentracing-spring-jaeger-cloud-starter</artifactId>-->
-            <!--<version>${opentracing.jaeger.version}</version>-->
-            <!--<optional>true</optional>-->
-        <!--</dependency>-->
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -44,6 +44,8 @@
             <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
             <version>0.1.0</version>
         </dependency>
+
+        <!-- THIS IS THE FULL FLEDGE STARTER WITH JAEGER WIRING -->
         <!--<dependency>-->
             <!--<groupId>io.opentracing.contrib</groupId>-->
             <!--<artifactId>opentracing-spring-jaeger-cloud-starter</artifactId>-->

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -45,6 +45,15 @@
             <version>0.1.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <version>0.31.0</version>
+            <scope>test</scope>
+        </dependency>
+
+
+
         <!-- THIS IS THE FULL FLEDGE STARTER WITH JAEGER WIRING -->
         <!--<dependency>-->
             <!--<groupId>io.opentracing.contrib</groupId>-->
@@ -59,6 +68,7 @@
             <version>${spring.version}</version>
             <optional>true</optional>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapExtractor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapExtractor.java
@@ -24,6 +24,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+/**
+ * @author Christophe Bouhier
+ * @since 4.0
+ */
 public class MapExtractor implements TextMap {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MapExtractor.class);

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapExtractor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapExtractor.java
@@ -25,6 +25,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
+ * An implementation of {@link TextMap}, to extract tracing fields from {@link MetaData}
+ *
  * @author Christophe Bouhier
  * @since 4.0
  */

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapExtractor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.propagation.TextMap;

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
@@ -23,7 +23,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-
+/**
+ * @author Christophe Bouhier
+ * @since 4.0
+ */
 public class MapInjector implements TextMap {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MapInjector.class);

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
@@ -16,6 +16,7 @@
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.propagation.TextMap;
+import org.axonframework.messaging.MetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
+ * An implementation of {@link TextMap}, to inject tracing fields with {@link MetaData}
+ *
  * @author Christophe Bouhier
  * @since 4.0
  */

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.propagation.TextMap;

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
@@ -41,22 +41,17 @@ public class OpenTraceDispatchInterceptor implements MessageDispatchInterceptor<
     @Override
     public BiFunction<Integer, Message<?>, Message<?>> handle(List<? extends Message<?>> messages) {
 
+
         ScopeManager scopeManager = tracer.scopeManager();
         Optional<SpanContext> spanContextOptional = Optional.ofNullable(scopeManager)
                 .map(ScopeManager::active)
                 .map(Scope::span)
                 .map(Span::context);
 
-        if (spanContextOptional.isPresent()) {
-            Optional<? extends Message<?>> singleMessage = messages.stream()
-                    .map(m -> {
-                        MapInjector injector = new MapInjector();
-                        tracer.inject(spanContextOptional.get(), Format.Builtin.TEXT_MAP, injector);
-                        return m.andMetaData(injector.getMetaData());
-                    }).findAny();
-            return singleMessage.<BiFunction<Integer, Message<?>, Message<?>>>map(message -> (i, m) -> message).orElseGet(() -> (i, m) -> m);
-        } else {
-            return (i, m) -> m;
-        }
+        return spanContextOptional.<BiFunction<Integer, Message<?>, Message<?>>>map(spanContext -> (index, message) -> {
+            MapInjector injector = new MapInjector();
+            tracer.inject(spanContext, Format.Builtin.TEXT_MAP, injector);
+            return message.andMetaData(injector.getMetaData());
+        }).orElseGet(() -> (i, m) -> m);
     }
 }

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.*;
@@ -9,6 +39,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
+/**
+ * A {@link MessageDispatchInterceptor} which maps the {@link SpanContext} to {@link org.axonframework.messaging.MetaData}
+ *
+ * @author Christophe Bouhier
+ */
 public class OpenTraceDispatchInterceptor implements MessageDispatchInterceptor<Message<?>> {
 
     private final Tracer tracer;

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.*;
@@ -43,6 +28,7 @@ import java.util.function.BiFunction;
  * A {@link MessageDispatchInterceptor} which maps the {@link SpanContext} to {@link org.axonframework.messaging.MetaData}
  *
  * @author Christophe Bouhier
+ * @since 4.0
  */
 public class OpenTraceDispatchInterceptor implements MessageDispatchInterceptor<Message<?>> {
 

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.Scope;
@@ -8,15 +38,18 @@ import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.messaging.InterceptorChain;
-import org.axonframework.messaging.Message;
-import org.axonframework.messaging.MessageHandlerInterceptor;
-import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.*;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.queryhandling.QueryMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
+/**
+ * A {@link MessageHandlerInterceptor} which maps the {@link MetaData} to the {@link SpanContext}.
+ *
+ * @author Christophe Bouhier
+ */
 public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Message<?>> {
 
     private final Logger LOGGER = LoggerFactory.getLogger(OpenTraceHandlerInterceptor.class);
@@ -52,6 +85,7 @@ public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Me
 
         try(Scope scope = spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER).startActive(false)){
 
+            //noinspection unchecked
             unitOfWork.onCleanup(u -> {
                 scope.span().finish();
             });

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
@@ -43,6 +43,7 @@ public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Me
 
     static final String TAG_AXON_PAYLOAD_TYPE = "axon.payload.type";
     static final String TAG_AXON_ID = "axon.id";
+    static final String TAG_AXON_MSG_TYPE = "axon.message.type" ;
 
     private final Logger LOGGER = LoggerFactory.getLogger(OpenTraceHandlerInterceptor.class);
 
@@ -89,9 +90,8 @@ public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Me
         Class payloadType = message.getPayloadType();
         String messageType = resolveType(message);
 
-//        span.setOperationName(String.format("%s %s", messageType, payloadType.getSimpleName()));
-
         span.setTag(TAG_AXON_ID, message.getIdentifier());
+        span.setTag(TAG_AXON_MSG_TYPE, messageType);
         span.setTag(TAG_AXON_PAYLOAD_TYPE, payloadType.getName());
 
         LOGGER.info("Called: {}", message);

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.Scope;
@@ -49,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * A {@link MessageHandlerInterceptor} which maps the {@link MetaData} to the {@link SpanContext}.
  *
  * @author Christophe Bouhier
+ * @since 4.0
  */
 public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Message<?>> {
 

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.Scope;
@@ -7,6 +38,11 @@ import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A tracing command gateway which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
+ *
+ * @author Christophe Bouhier
+ */
 public class TracingCommandGateway extends DefaultCommandGateway {
 
     private final Tracer tracer;

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.Scope;
@@ -42,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
  * A tracing command gateway which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
  *
  * @author Christophe Bouhier
+ * @since 4.0
  */
 public class TracingCommandGateway extends DefaultCommandGateway {
 

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -18,9 +18,14 @@ package org.axonframework.extensions.tracing;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import org.axonframework.commandhandling.CommandCallback;
+import org.axonframework.commandhandling.CommandExecutionException;
+import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.callbacks.FutureCallback;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A tracing command gateway which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
@@ -40,14 +45,94 @@ public class TracingCommandGateway extends DefaultCommandGateway {
     @SuppressWarnings("unchecked")
     @Override
     public <R> CompletableFuture<R> send(Object command) {
-        Span parentSpan = tracer.activeSpan();
+        return sendWithSpan(tracer, (tracer, parentSpan, childSpan) -> (CompletableFuture<R>) super.send(command)
+                .whenComplete((r, e) -> {
+                    childSpan.finish();
+                    tracer.scopeManager().activate(parentSpan, false);
+                }));
+    }
+
+    @Override
+    public <C, R> void send(C command, CommandCallback<? super C, ? super R> callback) {
+
+        sendWithSpan(tracer, (tracer, parentSpan, childSpan) -> {
+            super.send(command, callback);
+            childSpan.finish();
+            tracer.scopeManager().activate(parentSpan, false);
+        });
+    }
+
+    @Override
+    public <R> R sendAndWait(Object command) {
+
+        FutureCallback<Object, R> futureCallback = new FutureCallback<>();
+
+        sendAndRestoreParentSpan(command, futureCallback);
+        CommandResultMessage<? extends R> commandResultMessage = futureCallback.getResult();
+        if (commandResultMessage.isExceptional()) {
+            throw asRuntime(commandResultMessage.exceptionResult());
+        }
+        return commandResultMessage.getPayload();
+    }
+
+    @Override
+    public <R> R sendAndWait(Object command, long timeout, TimeUnit unit) {
+
+        FutureCallback<Object, R> futureCallback = new FutureCallback<>();
+
+        sendAndRestoreParentSpan(command, futureCallback);
+        CommandResultMessage<? extends R> commandResultMessage = futureCallback.getResult(timeout, unit);
+        if (commandResultMessage.isExceptional()) {
+            throw asRuntime(commandResultMessage.exceptionResult());
+        }
+        return commandResultMessage.getPayload();
+    }
+
+    private <R> void sendAndRestoreParentSpan(Object command, FutureCallback<Object, R> futureCallback) {
+        sendWithSpan(tracer, (tracer, parentSpan, childSpan) -> {
+            super.send(command, futureCallback);
+            futureCallback.whenComplete((r, e) -> {
+                childSpan.finish();
+                tracer.scopeManager().activate(parentSpan, false);
+            });
+
+        });
+    }
+
+    private RuntimeException asRuntime(Throwable e) {
+        Throwable failure = e.getCause();
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        } else if (failure instanceof RuntimeException) {
+            return (RuntimeException) failure;
+        } else {
+            return new CommandExecutionException("An exception occurred while executing a command", failure);
+        }
+    }
+
+    private void sendWithSpan(Tracer tracer, SpanConsumer consumer) {
+        Span parent = tracer.activeSpan();
         try (Scope scope = tracer.buildSpan("command").startActive(false)) {
             Span span = scope.span();
-            return (CompletableFuture<R>) super.send(command)
-                    .whenComplete((r, e) -> {
-                        span.finish();
-                        tracer.scopeManager().activate(parentSpan, false);
-                    });
+            consumer.accept(tracer, parent, span);
         }
+    }
+
+    private <R> R sendWithSpan(Tracer tracer, SpanFunction<R> function) {
+        Span parent = tracer.activeSpan();
+        try (Scope scope = tracer.buildSpan("command").startActive(false)) {
+            Span span = scope.span();
+            return function.accept(tracer, parent, span);
+        }
+    }
+
+    @FunctionalInterface
+    public interface SpanConsumer {
+        void accept(Tracer tracer, Span activeSpan, Span parentSpan);
+    }
+
+    @FunctionalInterface
+    public interface SpanFunction<R> {
+        R accept(Tracer tracer, Span activeSpan, Span parentSpan);
     }
 }

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -45,11 +45,7 @@ public class TracingCommandGateway extends DefaultCommandGateway {
     @SuppressWarnings("unchecked")
     @Override
     public <R> CompletableFuture<R> send(Object command) {
-        return sendWithSpan(tracer, (tracer, parentSpan, childSpan) -> (CompletableFuture<R>) super.send(command)
-                .whenComplete((r, e) -> {
-                    childSpan.finish();
-                    tracer.scopeManager().activate(parentSpan, false);
-                }));
+        return (CompletableFuture<R>) super.send(command);
     }
 
     @Override
@@ -95,7 +91,6 @@ public class TracingCommandGateway extends DefaultCommandGateway {
                 childSpan.finish();
                 tracer.scopeManager().activate(parentSpan, false);
             });
-
         });
     }
 

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingProvider.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.correlation.CorrelationDataProvider;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * A {@link CorrelationDataProvider provider} which {@link MapInjector injects} a message {@link MetaData} with the active span.
+ *
+ * @author Christophe Bouhier
+ * @since 4.0
+ */
+public class TracingProvider implements CorrelationDataProvider {
+
+    private Tracer tracer;
+
+    public TracingProvider(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public Map<String, ?> correlationDataFor(Message<?> message) {
+        return ofNullable(tracer.activeSpan())
+                .map(
+                        activeSpan -> {
+                            MapInjector injector = new MapInjector();
+                            tracer.inject(activeSpan.context(), Format.Builtin.TEXT_MAP, injector);
+                            return injector.getMetaData();
+                        }
+                ).orElseGet(Collections::emptyMap);
+    }
+}

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
@@ -41,7 +41,7 @@ public class TracingQueryGateway extends DefaultQueryGateway {
     @Override
     public <R, Q> CompletableFuture<R> query(String queryName, Q query, ResponseType<R> responseType) {
         Span parentSpan = tracer.activeSpan();
-        try (Scope scope = tracer.buildSpan("query").startActive(false)) {
+        try (Scope scope = tracer.buildSpan(queryName).startActive(false)) {
             Span span = scope.span();
             return super.query(queryName, query, responseType).whenComplete((r, e) -> {
                 span.finish();

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.Scope;
@@ -8,6 +39,11 @@ import org.axonframework.queryhandling.DefaultQueryGateway;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A tracing query gateway which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
+ *
+ * @author Christophe Bouhier
+ */
 public class TracingQueryGateway extends DefaultQueryGateway {
 
     private final Tracer tracer;

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.extensions.tracing;
 
 import io.opentracing.Scope;
@@ -43,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
  * A tracing query gateway which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
  *
  * @author Christophe Bouhier
+ * @since 4.0
  */
 public class TracingQueryGateway extends DefaultQueryGateway {
 

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/MapExtractorTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/MapExtractorTest.java
@@ -1,0 +1,41 @@
+package org.axonframework.extensions.tracing;
+
+import org.axonframework.messaging.MetaData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JUnit4.class)
+public class MapExtractorTest {
+
+    @Test
+    public void testExtractor() {
+
+        MetaData metaData = MetaData.emptyInstance();
+        metaData = metaData.and("key", "value");
+
+        MapExtractor extractor = new MapExtractor(metaData);
+        Iterator<Map.Entry<String, String>> iterator = extractor.iterator();
+
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.next().getValue(), is("value"));
+
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnssuported() {
+
+        MetaData metaData = MetaData.emptyInstance();
+        metaData = metaData.and("key", "value");
+
+        MapExtractor extractor = new MapExtractor(metaData);
+        extractor.put("key1", "value1");
+    }
+
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/MapInjectorTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/MapInjectorTest.java
@@ -1,0 +1,28 @@
+package org.axonframework.extensions.tracing;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertThat;
+
+@RunWith(JUnit4.class)
+public class MapInjectorTest {
+
+    @Test
+    public void testInject() {
+        MapInjector injector = new MapInjector();
+        injector.put("key", "value");
+        Map<String, String> metaData = injector.getMetaData();
+        assertThat(metaData.get("key"), CoreMatchers.is("value"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupported() {
+        MapInjector injector = new MapInjector();
+        injector.iterator();
+    }
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptorTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptorTest.java
@@ -1,0 +1,63 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MetaData;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static java.lang.Long.valueOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenTraceDispatchInterceptorTest {
+
+    private OpenTraceDispatchInterceptor openTraceDispatchInterceptor;
+    private MockTracer mockTracer;
+
+    @Before
+    public void before() {
+
+        mockTracer = new MockTracer();
+        openTraceDispatchInterceptor = new OpenTraceDispatchInterceptor(mockTracer);
+    }
+
+    @Test
+    public void testDispatch() {
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, false);
+
+        GenericMessage<String> msg = new GenericMessage<>("Payload");
+        BiFunction<Integer, Message<?>, Message<?>> handle = openTraceDispatchInterceptor.handle(Collections
+                .singletonList(msg));
+
+        // This interceptor has no side effects on the spans in the tracer.
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.isEmpty(), is(true));
+
+        Message<?> apply = handle.apply(0, msg);
+        MetaData metaData = apply.getMetaData();
+        assertThat(metaData.size(), is(2));
+        assertThat(metaData.get("spanid"), is(valueOf(span.context().spanId()).toString()));
+        assertThat(metaData.get("traceid"), is(valueOf(span.context().traceId()).toString()));
+    }
+
+    @After
+    public void after(){
+        mockTracer.scopeManager().active().close();
+    }
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptorTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptorTest.java
@@ -1,0 +1,78 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.InterceptorChain;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenTraceHandlerInterceptorTest {
+
+    private MockTracer mockTracer;
+    private OpenTraceHandlerInterceptor openTraceDispatchInterceptor;
+    private DefaultUnitOfWork<Message<?>> unitOfWork;
+    private InterceptorChain mockInterceptorChain;
+
+    @Before
+    public void before() {
+
+        mockTracer = new MockTracer();
+        openTraceDispatchInterceptor = new OpenTraceHandlerInterceptor(mockTracer);
+        mockInterceptorChain = mock(InterceptorChain.class);
+        unitOfWork = new DefaultUnitOfWork<>(null);
+    }
+
+    @Test
+    public void testHandle() throws Exception {
+
+        MockSpan test = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(test, true);
+
+        Message message = new GenericMessage<Object>("Payload").withMetaData(new HashMap<String, String>() {{
+            put("spanid", "1");
+            put("traceid", "2");
+        }});
+
+        unitOfWork.transformMessage(m -> message);
+
+        openTraceDispatchInterceptor.handle(unitOfWork, mockInterceptorChain);
+
+        // Push the state, so the child span is finished.
+        unitOfWork.start();
+        unitOfWork.commit();
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.size(), is(1));
+        MockSpan mockSpan = mockSpans.get(0);
+        assertThat(mockSpan.parentId(), is(1L));
+        assertThat(mockSpan.context().traceId(), is(2L));
+
+        assertThat(mockSpan.operationName(), is("Extracting"));
+        assertThat(mockSpan.tags().get(OpenTraceHandlerInterceptor.TAG_AXON_ID), is(message.getIdentifier()));
+        assertThat(mockSpan.tags().get(OpenTraceHandlerInterceptor.TAG_AXON_PAYLOAD_TYPE), is("java.lang.String"));
+
+        assertThat(mockSpan.tags().get(Tags.SPAN_KIND.getKey()), is(Tags.SPAN_KIND_SERVER));
+    }
+
+    @After
+    public void after(){
+        mockTracer.scopeManager().active().close();
+    }
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptorTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptorTest.java
@@ -66,6 +66,7 @@ public class OpenTraceHandlerInterceptorTest {
 
         assertThat(mockSpan.operationName(), is("Extracting"));
         assertThat(mockSpan.tags().get(OpenTraceHandlerInterceptor.TAG_AXON_ID), is(message.getIdentifier()));
+        assertThat(mockSpan.tags().get(OpenTraceHandlerInterceptor.TAG_AXON_MSG_TYPE), is("Message"));
         assertThat(mockSpan.tags().get(OpenTraceHandlerInterceptor.TAG_AXON_PAYLOAD_TYPE), is("java.lang.String"));
 
         assertThat(mockSpan.tags().get(Tags.SPAN_KIND.getKey()), is(Tags.SPAN_KIND_SERVER));

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
@@ -1,0 +1,162 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandCallback;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.axonframework.commandhandling.GenericCommandResultMessage.asCommandResultMessage;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+
+public class TracingCommandGatewayTest {
+
+
+    private CommandBus mockCommandBus;
+    private MockTracer mockTracer;
+
+    private TracingCommandGateway testSubject;
+
+    @Before
+    public void before() {
+        mockCommandBus = mock(CommandBus.class);
+        mockTracer = new MockTracer();
+
+        DefaultCommandGateway.Builder builder = DefaultCommandGateway.builder().commandBus(mockCommandBus);
+        testSubject = new TracingCommandGateway(builder, mockTracer);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSendWithCallback() {
+
+        doAnswer(invocation -> {
+            ((CommandCallback) invocation.getArguments()[1])
+                    .onResult((CommandMessage) invocation.getArguments()[0],
+                            asCommandResultMessage("result"));
+            return null;
+        }).when(mockCommandBus).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, false);
+
+
+        testSubject.send("Command", (m, r) -> {
+            // Call back.
+            assertThat(r, notNullValue());
+        });
+
+        verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+        // Verify the parent span is restored, and that a child span was finished.
+        Span activeSpan = mockTracer.activeSpan();
+        assertThat(activeSpan, is(span));
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.size(), is(1));
+        assertThat(mockSpans.get(0).operationName(), is("command"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSendWithoutCallback() throws ExecutionException, InterruptedException {
+
+        doAnswer(invocation -> {
+            ((CommandCallback) invocation.getArguments()[1])
+                    .onResult((CommandMessage) invocation.getArguments()[0],
+                            asCommandResultMessage("result"));
+            return null;
+        }).when(mockCommandBus).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, false);
+
+
+        CompletableFuture<Object> future = testSubject.send("Command");
+
+        verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+        assertThat(future.isDone(), is(true));
+        assertThat(future.get(), is("result"));
+
+        // Verify the parent span is restored, and that a child span was finished.
+        Span activeSpan = mockTracer.activeSpan();
+        assertThat(activeSpan, is(span));
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.size(), is(1));
+        assertThat(mockSpans.get(0).operationName(), is("command"));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSendAndWait() {
+
+        doAnswer(invocation -> {
+            ((CommandCallback) invocation.getArguments()[1])
+                    .onResult((CommandMessage) invocation.getArguments()[0],
+                            asCommandResultMessage("result"));
+            return null;
+        }).when(mockCommandBus).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, false);
+
+        Object result = testSubject.sendAndWait("Command");
+
+        verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+        assertThat(result, instanceOf(String.class));
+        assertThat(result, is("result"));
+
+
+        Span activeSpan = mockTracer.activeSpan();
+        assertThat(activeSpan, is(span));
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.size(), is(1));
+        assertThat(mockSpans.get(0).operationName(), is("command"));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSendAndWaitWithTimeout() {
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, false);
+
+        Object result = testSubject.sendAndWait("Command", 10, TimeUnit.MILLISECONDS);
+
+        verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
+
+        assertThat(result, nullValue());
+
+
+        Span activeSpan = mockTracer.activeSpan();
+        assertThat(activeSpan, is(span));
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.size(), is(0));
+    }
+
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
@@ -69,7 +69,7 @@ public class TracingCommandGatewayTest {
 
         List<MockSpan> mockSpans = mockTracer.finishedSpans();
         assertThat(mockSpans.size(), is(1));
-        assertThat(mockSpans.get(0).operationName(), is("command"));
+        assertThat(mockSpans.get(0).operationName(), is("java.lang.String"));
     }
 
     @SuppressWarnings("unchecked")
@@ -101,7 +101,7 @@ public class TracingCommandGatewayTest {
 
         List<MockSpan> mockSpans = mockTracer.finishedSpans();
         assertThat(mockSpans.size(), is(1));
-        assertThat(mockSpans.get(0).operationName(), is("command"));
+        assertThat(mockSpans.get(0).operationName(), is("java.lang.String"));
 
     }
 
@@ -133,7 +133,7 @@ public class TracingCommandGatewayTest {
 
         List<MockSpan> mockSpans = mockTracer.finishedSpans();
         assertThat(mockSpans.size(), is(1));
-        assertThat(mockSpans.get(0).operationName(), is("command"));
+        assertThat(mockSpans.get(0).operationName(), is("java.lang.String"));
 
     }
 

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingProviderTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingProviderTest.java
@@ -1,0 +1,55 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MetaData;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TracingProviderTest {
+
+    private MockTracer mockTracer;
+
+    @Before
+    public void before() {
+        mockTracer = new MockTracer();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        System.out.println(scopeManager.active());
+    }
+
+    @Test
+    public void testTracingProvider() {
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, true);
+
+        Message message = new GenericMessage<>("payload", MetaData.emptyInstance());
+
+        TracingProvider tracingProvider = new TracingProvider(mockTracer);
+
+        Map<String, ?> correlated = tracingProvider.correlationDataFor(message);
+
+        assertThat(correlated.get("spanid"), is(Long.valueOf(span.context().spanId()).toString()));
+        assertThat(correlated.get("traceid"), is(Long.valueOf(span.context().traceId()).toString()));
+    }
+
+    @Test
+    public void testTracingProviderEmptyTraceContext(){
+
+        Message message = new GenericMessage<>("payload", MetaData.emptyInstance());
+        TracingProvider tracingProvider = new TracingProvider(mockTracer);
+        Map<String, ?> correlated = tracingProvider.correlationDataFor(message);
+        assertThat(correlated.isEmpty(), is(true));
+    }
+
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingProviderTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingProviderTest.java
@@ -6,7 +6,6 @@ import io.opentracing.mock.MockTracer;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,7 +22,6 @@ public class TracingProviderTest {
     public void before() {
         mockTracer = new MockTracer();
         ScopeManager scopeManager = mockTracer.scopeManager();
-        System.out.println(scopeManager.active());
     }
 
     @Test
@@ -44,7 +42,7 @@ public class TracingProviderTest {
     }
 
     @Test
-    public void testTracingProviderEmptyTraceContext(){
+    public void testTracingProviderEmptyTraceContext() {
 
         Message message = new GenericMessage<>("payload", MetaData.emptyInstance());
         TracingProvider tracingProvider = new TracingProvider(mockTracer);

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingQueryGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingQueryGatewayTest.java
@@ -1,0 +1,69 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.axonframework.queryhandling.*;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TracingQueryGatewayTest {
+
+    private QueryBus mockQueryBus;
+    private MockTracer mockTracer;
+    private TracingQueryGateway testSubject;
+    private QueryResponseMessage<String> answer;
+
+    @Before
+    public void before() {
+
+        mockQueryBus = mock(QueryBus.class);
+        mockTracer = new MockTracer();
+
+        DefaultQueryGateway.Builder builder = DefaultQueryGateway.builder().queryBus(mockQueryBus);
+        testSubject = new TracingQueryGateway(builder, mockTracer);
+
+        answer = new GenericQueryResponseMessage<>("answer");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testQuery() throws ExecutionException, InterruptedException {
+
+        when(mockQueryBus.query(ArgumentMatchers.any(QueryMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(answer));
+
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        scopeManager.activate(span, false);
+
+        CompletableFuture<String> query = testSubject.query("query", "Query", String.class);
+        assertThat(query.get(), CoreMatchers.is("answer"));
+
+
+        // Verify the parent span is restored, and that a child span was finished.
+        Span activeSpan = mockTracer.activeSpan();
+        assertThat(activeSpan, is(span));
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat(mockSpans.size(), is(1));
+        assertThat(mockSpans.get(0).operationName(), is("query"));
+
+
+    }
+
+}


### PR DESCRIPTION
@smcvb @abuijze Initial push for auto-configure opentracing, for some early feedback. 
This PR resolve issue #2.

Some open questions/issues. 
 
- The tracing module, has a dependency on opentracing, not sure how we can make this extension support multiple implementations (opentracing.io and brave). 
- Probably some conditions missing on required beans. 
- We could have a property/flag to enable tracing.
- Still missing, is the correlation provider. 
- We have no binding with a Trace reporter like Jaeger. Not sure how much out of the box experience is required.
- Unit tests missing

What is your approach for testing extensions? 
