### PR TITLE
Upgrade to Axon 4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     </profiles>
 
     <properties>
-        <axon.version>4.0</axon.version>
+        <axon.version>4.2</axon.version>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <spring.version>5.1.1.RELEASE</spring.version>

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
  * Auto configure a tracing capabilities.
  *
  * @author Christophe Bouhier
+ * @author Steven van Beelen
  * @since 4.0
  */
 @Configuration
@@ -58,30 +59,32 @@ public class TracingAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public QueryGateway queryGateway(QueryBus queryBus,
+    public QueryGateway queryGateway(Tracer tracer,
+                                     QueryBus queryBus,
                                      OpenTraceDispatchInterceptor openTraceDispatchInterceptor,
-                                     OpenTraceHandlerInterceptor openTraceHandlerInterceptor,
-                                     Tracer tracer) {
+                                     OpenTraceHandlerInterceptor openTraceHandlerInterceptor) {
         queryBus.registerHandlerInterceptor(openTraceHandlerInterceptor);
-        return TracingQueryGateway.builder()
-                                  .queryBus(queryBus)
-                                  .dispatchInterceptors(openTraceDispatchInterceptor)
-                                  .tracer(tracer)
-                                  .build();
+        TracingQueryGateway tracingQueryGateway = TracingQueryGateway.builder()
+                                                                     .delegateQueryBus(queryBus)
+                                                                     .tracer(tracer)
+                                                                     .build();
+        tracingQueryGateway.registerDispatchInterceptor(openTraceDispatchInterceptor);
+        return tracingQueryGateway;
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public CommandGateway commandGateway(CommandBus commandBus,
+    public CommandGateway commandGateway(Tracer tracer,
+                                         CommandBus commandBus,
                                          OpenTraceDispatchInterceptor openTraceDispatchInterceptor,
-                                         OpenTraceHandlerInterceptor openTraceHandlerInterceptor,
-                                         Tracer tracer) {
+                                         OpenTraceHandlerInterceptor openTraceHandlerInterceptor) {
         commandBus.registerHandlerInterceptor(openTraceHandlerInterceptor);
-        return TracingCommandGateway.builder()
-                                    .commandBus(commandBus)
-                                    .dispatchInterceptors(openTraceDispatchInterceptor)
-                                    .tracer(tracer)
-                                    .build();
+        TracingCommandGateway tracingCommandGateway = TracingCommandGateway.builder()
+                                                                           .tracer(tracer)
+                                                                           .delegateCommandBus(commandBus)
+                                                                           .build();
+        tracingCommandGateway.registerDispatchInterceptor(openTraceDispatchInterceptor);
+        return tracingCommandGateway;
     }
 
     @Bean

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -25,13 +25,18 @@ import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.commandhandling.GenericCommandResultMessage;
+import org.axonframework.commandhandling.callbacks.FailureLoggingCallback;
 import org.axonframework.commandhandling.callbacks.FutureCallback;
+import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
-import org.axonframework.commandhandling.gateway.RetryScheduler;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.List;
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -40,35 +45,32 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.extensions.tracing.SpanUtils.withMessageTags;
 
 /**
- * A tracing command gateway which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
+ * A tracing {@link CommandGateway} which activates a calling {@link Span}, when the {@link CompletableFuture}
+ * completes. This implementation is a wrapper and as such delegates the actual dispatching of commands to another
+ * CommandGateway.
  *
  * @author Christophe Bouhier
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 4.0
  */
-public class TracingCommandGateway extends DefaultCommandGateway {
+public class TracingCommandGateway implements CommandGateway {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final Tracer tracer;
-
-    /**
-     * Instantiate a {@link TracingCommandGateway} based on the fields contained in the {@link Builder}.
-     * <p>
-     * Will assert that the {@link CommandBus} and {@link Tracer} are not {@code null}, and will throw an
-     * {@link AxonConfigurationException} if they are.
-     *
-     * @param builder the {@link Builder} used to instantiate a {@link TracingCommandGateway} instance
-     */
-    protected TracingCommandGateway(Builder builder) {
-        super(builder);
-        this.tracer = builder.tracer;
-    }
+    private final CommandGateway delegate;
 
     /**
      * Instantiate a Builder to be able to create a {@link TracingCommandGateway}.
      * <p>
-     * The {@code dispatchInterceptors} are defaulted to an empty list.
-     * The {@link Tracer} and {@link CommandBus} are <b>hard requirements</b> and as such should be provided.
+     * Either a {@link CommandBus} or {@link CommandGateway} can be provided to be used to delegate the dispatching of
+     * commands to. If a CommandBus is provided directly, it will be used to instantiate a
+     * {@link DefaultCommandGateway}. A registered CommandGateway will always take precedence over a configured
+     * CommandBus.
+     * <p>
+     * The {@link Tracer} and delegate {@link CommandGateway} are <b>hard requirements</b> and as such should be
+     * provided.
      *
      * @return a Builder to be able to create a {@link TracingCommandGateway}
      */
@@ -76,12 +78,26 @@ public class TracingCommandGateway extends DefaultCommandGateway {
         return new Builder();
     }
 
+    /**
+     * Instantiate a {@link TracingCommandGateway} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@link Tracer} and delegate {@link CommandGateway} are not {@code null}, and will throw an
+     * {@link AxonConfigurationException} if they are.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link TracingCommandGateway} instance
+     */
+    protected TracingCommandGateway(Builder builder) {
+        builder.validate();
+        this.tracer = builder.tracer;
+        this.delegate = builder.buildDelegateCommandGateway();
+    }
+
     @Override
     public <C, R> void send(C command, CommandCallback<? super C, ? super R> callback) {
         CommandMessage<?> cmd = GenericCommandMessage.asCommandMessage(command);
         sendWithSpan(tracer, "sendCommandMessage", cmd, (tracer, parentSpan, childSpan) -> {
             CompletableFuture<?> resultReceived = new CompletableFuture<>();
-            super.send(command, (CommandCallback<C, R>) (commandMessage, commandResultMessage) -> {
+            delegate.send(command, (CommandCallback<C, R>) (commandMessage, commandResultMessage) -> {
                 try (Scope ignored = tracer.scopeManager().activate(parentSpan, false)) {
                     childSpan.log("resultReceived");
                     callback.onResult(commandMessage, commandResultMessage);
@@ -105,6 +121,26 @@ public class TracingCommandGateway extends DefaultCommandGateway {
         return doSendAndExtract(command, f -> f.getResult(timeout, unit));
     }
 
+    @Override
+    public <R> CompletableFuture<R> send(Object command) {
+        FutureCallback<Object, R> callback = new FutureCallback<>();
+        send(command, new FailureLoggingCallback<>(logger, callback));
+        CompletableFuture<R> result = new CompletableFuture<>();
+        callback.exceptionally(GenericCommandResultMessage::asCommandResultMessage)
+                .thenAccept(r -> {
+                    try {
+                        if (r.isExceptional()) {
+                            result.completeExceptionally(r.exceptionResult());
+                        } else {
+                            result.complete(r.getPayload());
+                        }
+                    } catch (Exception e) {
+                        result.completeExceptionally(e);
+                    }
+                });
+        return result;
+    }
+
     private <R> R doSendAndExtract(Object command,
                                    Function<FutureCallback<Object, R>, CommandResultMessage<? extends R>> resultExtractor) {
         FutureCallback<Object, R> futureCallback = new FutureCallback<>();
@@ -120,12 +156,22 @@ public class TracingCommandGateway extends DefaultCommandGateway {
     private <R> void sendAndRestoreParentSpan(Object command, FutureCallback<Object, R> futureCallback) {
         CommandMessage<?> cmd = GenericCommandMessage.asCommandMessage(command);
         sendWithSpan(tracer, "sendCommandMessageAndWait", cmd, (tracer, parentSpan, childSpan) -> {
-            super.send(cmd, futureCallback);
+            delegate.send(cmd, futureCallback);
             futureCallback.thenRun(() -> childSpan.log("resultReceived"));
 
             childSpan.log("dispatchComplete");
             futureCallback.thenRun(childSpan::finish);
         });
+    }
+
+    private void sendWithSpan(Tracer tracer, String operation, CommandMessage<?> command, SpanConsumer consumer) {
+        Span parent = tracer.activeSpan();
+        Tracer.SpanBuilder spanBuilder = withMessageTags(tracer.buildSpan(operation), command)
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+        try (Scope scope = spanBuilder.startActive(false)) {
+            consumer.accept(tracer, parent, scope.span());
+        }
+        tracer.scopeManager().activate(parent, false);
     }
 
     private RuntimeException asRuntime(Throwable e) {
@@ -139,14 +185,10 @@ public class TracingCommandGateway extends DefaultCommandGateway {
         }
     }
 
-    private void sendWithSpan(Tracer tracer, String operation, CommandMessage<?> command, SpanConsumer consumer) {
-        Span parent = tracer.activeSpan();
-        Tracer.SpanBuilder spanBuilder = withMessageTags(tracer.buildSpan(operation), command)
-                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
-        try (Scope scope = spanBuilder.startActive(false)) {
-            consumer.accept(tracer, parent, scope.span());
-        }
-        tracer.scopeManager().activate(parent, false);
+    @Override
+    public Registration registerDispatchInterceptor(
+            MessageDispatchInterceptor<? super CommandMessage<?>> dispatchInterceptor) {
+        return delegate.registerDispatchInterceptor(dispatchInterceptor);
     }
 
     @FunctionalInterface
@@ -158,38 +200,19 @@ public class TracingCommandGateway extends DefaultCommandGateway {
     /**
      * Builder class to instantiate a {@link TracingCommandGateway}.
      * <p>
-     * The {@code dispatchInterceptors} are defaulted to an empty list.
-     * The {@link Tracer} and {@link CommandBus} are <b>hard requirements</b> and as such should be provided.
+     * Either a {@link CommandBus} or {@link CommandGateway} can be provided to be used to delegate the dispatching of
+     * commands to. If a CommandBus is provided directly, it will be used to instantiate a
+     * {@link DefaultCommandGateway}. A registered CommandGateway will always take precedence over a configured
+     * CommandBus.
+     * <p>
+     * The {@link Tracer} and delegate {@link CommandGateway} are <b>hard requirements</b> and as such should be
+     * provided.
      */
-    public static class Builder extends DefaultCommandGateway.Builder {
+    public static class Builder {
 
         private Tracer tracer;
-
-        @Override
-        public Builder commandBus(CommandBus commandBus) {
-            super.commandBus(commandBus);
-            return this;
-        }
-
-        @Override
-        public Builder retryScheduler(RetryScheduler retryScheduler) {
-            super.retryScheduler(retryScheduler);
-            return this;
-        }
-
-        @Override
-        public Builder dispatchInterceptors(
-                MessageDispatchInterceptor<? super CommandMessage<?>>... dispatchInterceptors) {
-            super.dispatchInterceptors(dispatchInterceptors);
-            return this;
-        }
-
-        @Override
-        public Builder dispatchInterceptors(
-                List<MessageDispatchInterceptor<? super CommandMessage<?>>> dispatchInterceptors) {
-            super.dispatchInterceptors(dispatchInterceptors);
-            return this;
-        }
+        private CommandBus delegateBus;
+        private CommandGateway delegateGateway;
 
         /**
          * Sets the {@link Tracer} used to set a {@link Span} on dispatched {@link CommandMessage}s.
@@ -204,6 +227,33 @@ public class TracingCommandGateway extends DefaultCommandGateway {
         }
 
         /**
+         * Sets the {@link CommandBus} used to build a {@link DefaultCommandGateway} this tracing-wrapper will delegate
+         * the actual sending of commands towards.
+         *
+         * @param delegateBus the {@link CommandGateway} this tracing-wrapper will delegate the actual sending of
+         *                    commands towards
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder delegateCommandBus(CommandBus delegateBus) {
+            assertNonNull(delegateBus, "Delegate CommandBus may not be null");
+            this.delegateBus = delegateBus;
+            return this;
+        }
+
+        /**
+         * Sets the {@link CommandGateway} this tracing-wrapper will delegate the actual sending of commands towards.
+         *
+         * @param delegateGateway the {@link CommandGateway} this tracing-wrapper will delegate the actual sending of
+         *                        commands towards
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder delegateCommandGateway(CommandGateway delegateGateway) {
+            assertNonNull(delegateGateway, "Delegate CommandGateway may not be null");
+            this.delegateGateway = delegateGateway;
+            return this;
+        }
+
+        /**
          * Initializes a {@link TracingCommandGateway} as specified through this Builder.
          *
          * @return a {@link TracingCommandGateway} as specified through this Builder
@@ -212,10 +262,39 @@ public class TracingCommandGateway extends DefaultCommandGateway {
             return new TracingCommandGateway(this);
         }
 
-        @Override
+        /**
+         * Instantiate the delegate {@link CommandGateway} this tracing-wrapper gateway will uses to actually dispatch
+         * commands.
+         * Will either use the registered {@link CommandBus} (through {@link #delegateCommandBus(CommandBus)}) or a
+         * complete CommandGateway through {@link #delegateCommandGateway(CommandGateway)}.
+         *
+         * @return the delegate {@link CommandGateway} this tracing-wrapper gateway will uses to actually dispatch commands
+         */
+        private CommandGateway buildDelegateCommandGateway() {
+            return delegateGateway != null
+                    ? delegateGateway
+                    : DefaultCommandGateway.builder().commandBus(delegateBus).build();
+        }
+
+        /**
+         * Validate whether the fields contained in this Builder as set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
         protected void validate() throws AxonConfigurationException {
-            super.validate();
             assertNonNull(tracer, "The Tracer is a hard requirement and should be provided");
+            if (delegateBus == null) {
+                assertNonNull(
+                        delegateGateway, "The delegate CommandGateway is a hard requirement and should be provided"
+                );
+                return;
+            }
+            assertNonNull(
+                    delegateBus,
+                    "The delegate CommandBus is a hard requirement to create a delegate CommandGateway"
+                            + " and should be provided"
+            );
         }
     }
 }


### PR DESCRIPTION
Prepare a 4.2-M1 release of tracing, by firstly updating the Axon version to 4.2. 

Secondly, the gateway implementations should be converted to a wrapper instead of an extension of the existing gateways. 
This will make using the Tracing solution more lenient and more importantly ensure the new way of dealing with exceptions in a distributed mechanism is correctly supported.

To that end, this PR adjusts the `TracingCommandGateway`, `TracingQueryGateway` and the auto configuration to align with Axon 4.2.