### PR TITLE
[10] TracingCommandGateway clean up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,9 @@
 
         <mockito.version>3.0.0</mockito.version>
         <jackson.version>2.9.4</jackson.version>
+
+        <junit.version>4.12</junit.version>
+        <commons-io.version>2.6</commons-io.version>
     </properties>
 
     <dependencies>
@@ -132,11 +135,10 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -144,7 +146,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
@@ -187,7 +188,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
@@ -197,11 +197,11 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- Not pat of Java 9 by default. Adding it as a dependency makes it compatible with Java 8 -->
+            <!-- Not part of Java 9 by default. Adding it as a dependency makes it compatible with Java 8 -->
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/MapInjector.java
@@ -50,11 +50,11 @@ public class MapInjector implements TextMap {
     }
 
     /**
-     * Retrieve a {@link Map} of {@link String} to String of all the injected tracing fields used as input for
-     * {@link MetaData}.
+     * Retrieve a {@link Map} of {@link String} to String of all the injected tracing fields used as input for {@link
+     * MetaData}.
      *
-     * @return a {@link Map} of {@link String} to String  of all the injected tracing fields used as input for
-     * {@link MetaData}
+     * @return a {@link Map} of {@link String} to String  of all the injected tracing fields used as input for {@link
+     * MetaData}
      */
     public Map<String, String> getMetaData() {
         return metaData;

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceDispatchInterceptor.java
@@ -15,7 +15,6 @@
  */
 package org.axonframework.extensions.tracing;
 
-import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -29,8 +28,8 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 /**
- * A {@link MessageDispatchInterceptor} which maps the {@link SpanContext} to
- * {@link org.axonframework.messaging.MetaData}.
+ * A {@link MessageDispatchInterceptor} which maps the {@link SpanContext} to {@link
+ * org.axonframework.messaging.MetaData}.
  *
  * @author Christophe Bouhier
  * @since 4.0

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
@@ -42,7 +42,7 @@ public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Me
 
     /**
      * Initialize a {@link MessageHandlerInterceptor} implementation which uses the provided {@link Tracer} to map span
-     * information from the {@link Message} its {@link MetaData} on a {@link SpanContext}.
+     * information from the {@link Message}'s {@link MetaData} on a {@link SpanContext}.
      *
      * @param tracer the {@link Tracer} used to set a {@link SpanContext} on from a {@link Message}'s {@link MetaData}
      */
@@ -69,12 +69,12 @@ public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Me
             spanBuilder = tracer.buildSpan(operationName);
         }
 
-        final Span span = withMessageTags(spanBuilder, unitOfWork.getMessage()).withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER).start();
+        final Span span = withMessageTags(spanBuilder, unitOfWork.getMessage()).withTag(Tags.SPAN_KIND.getKey(),
+                                                                                        Tags.SPAN_KIND_SERVER).start();
         try (Scope ignored = tracer.activateSpan(span)) {
             //noinspection unchecked
             unitOfWork.onCleanup(u -> span.finish());
             return interceptorChain.proceed();
         }
     }
-
 }

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
@@ -7,7 +7,10 @@ import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.QueryMessage;
 
 /**
- * Utility class providing methods useful for attaching information to Spans
+ * Utility class providing methods useful for attaching information to Spans.
+ *
+ * @author Lucas Campos
+ * @since 4.0
  */
 public class SpanUtils {
 

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
@@ -3,7 +3,6 @@ package org.axonframework.extensions.tracing;
 import io.opentracing.Tracer;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.eventhandling.DomainEventMessage;
-import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.QueryMessage;
 
@@ -11,6 +10,7 @@ import org.axonframework.queryhandling.QueryMessage;
  * Utility class providing methods useful for attaching information to Spans
  */
 public class SpanUtils {
+
     private static final String TAG_AXON_PAYLOAD_TYPE = "axon.message.payloadtype";
     private static final String TAG_AXON_ID = "axon.message.id";
     private static final String TAG_AXON_AGGEGRATE_ID = "axon.message.aggregateIdentifier";
@@ -51,9 +51,9 @@ public class SpanUtils {
      */
     public static String messageName(Message message) {
         if (message instanceof QueryMessage) {
-            return messageName(message.getPayloadType(),((QueryMessage) message).getQueryName());
+            return messageName(message.getPayloadType(), ((QueryMessage) message).getQueryName());
         } else if (message instanceof CommandMessage) {
-            return messageName(message.getPayloadType(),((CommandMessage) message).getCommandName());
+            return messageName(message.getPayloadType(), ((CommandMessage) message).getCommandName());
         }
         return message.getPayloadType().getSimpleName();
     }

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -52,6 +52,7 @@ import static org.axonframework.extensions.tracing.SpanUtils.withMessageTags;
  * @author Christophe Bouhier
  * @author Allard Buijze
  * @author Steven van Beelen
+ * @author Lucas Campos
  * @since 4.0
  */
 public class TracingCommandGateway implements CommandGateway {

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingProvider.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingProvider.java
@@ -41,8 +41,8 @@ public class TracingProvider implements CorrelationDataProvider {
      * Initialize a {@link CorrelationDataProvider} implementation which uses the provided {@link Tracer} to set the
      * active span on a {@link Message}'s {@link MetaData}.
      *
-     * @param tracer the {@link Tracer} used to retrieve the active span to be placed on a {@link Message}'s
-     *               {@link MetaData}
+     * @param tracer the {@link Tracer} used to retrieve the active span to be placed on a {@link Message}'s {@link
+     *               MetaData}
      */
     public TracingProvider(Tracer tracer) {
         this.tracer = tracer;

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
@@ -8,8 +8,7 @@ import io.opentracing.mock.MockTracer;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandMessage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -18,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.commandhandling.GenericCommandResultMessage.asCommandResultMessage;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
@@ -44,14 +43,14 @@ public class TracingCommandGatewayTest {
         doAnswer(invocation -> {
             ((CommandCallback) invocation.getArguments()[1])
                     .onResult((CommandMessage) invocation.getArguments()[0],
-                            asCommandResultMessage("result"));
+                              asCommandResultMessage("result"));
             return null;
         }).when(mockCommandBus).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
 
         testSubject = TracingCommandGateway.builder()
-                .tracer(mockTracer)
-                .delegateCommandBus(mockCommandBus)
-                .build();
+                                           .tracer(mockTracer)
+                                           .delegateCommandBus(mockCommandBus)
+                                           .build();
     }
 
     @Test
@@ -60,10 +59,10 @@ public class TracingCommandGatewayTest {
         ScopeManager scopeManager = mockTracer.scopeManager();
         try (final Scope ignored = scopeManager.activate(span)) {
 
-        testSubject.send(new MyCommand(), (m, r) -> {
-            // Call back.
-            assertThat(r, notNullValue());
-        });
+            testSubject.send(new MyCommand(), (m, r) -> {
+                // Call back.
+                assertThat(r, notNullValue());
+            });
 
             //noinspection unchecked
             verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
@@ -110,7 +109,7 @@ public class TracingCommandGatewayTest {
         ScopeManager scopeManager = mockTracer.scopeManager();
         try (final Scope ignored = scopeManager.activate(span)) {
 
-        Object result = testSubject.sendAndWait(new MyCommand());
+            Object result = testSubject.sendAndWait(new MyCommand());
 
             //noinspection unchecked
             verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
@@ -133,7 +132,7 @@ public class TracingCommandGatewayTest {
         ScopeManager scopeManager = mockTracer.scopeManager();
         try (final Scope ignored = scopeManager.activate(span)) {
 
-        Object result = testSubject.sendAndWait(new MyCommand(), 10, TimeUnit.MILLISECONDS);
+            Object result = testSubject.sendAndWait(new MyCommand(), 10, TimeUnit.MILLISECONDS);
 
             //noinspection unchecked
             verify(mockCommandBus, times(1)).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
@@ -151,6 +150,6 @@ public class TracingCommandGatewayTest {
     }
 
     private static class MyCommand {
-    }
 
+    }
 }


### PR DESCRIPTION
I've cleaned up `TracingCommandGateway` as suggested on #10 (fixed the mixed parameter ordering and remove tracer since it is not needed).
Also did a general code formation based on AxonIQ standards.

The changes are separated in 2 commits aiming to make the review easier.

This PR closes #10.