### PR TITLE
[#24] Removed the extra parentSpan activation

### DIFF
--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingCommandGateway.java
@@ -169,7 +169,6 @@ public class TracingCommandGateway implements CommandGateway {
         try (Scope ignored = tracer.activateSpan(childSpan)) {
             consumer.accept(parentSpan, childSpan);
         }
-        tracer.activateSpan(parentSpan);
     }
 
     private RuntimeException asRuntime(Throwable e) {

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
@@ -89,7 +89,6 @@ public class TracingQueryGateway implements QueryGateway {
         try (Scope ignored = tracer.activateSpan(span)) {
             return delegate.query(queryName, query, responseType).whenComplete((r, e) -> {
                 span.finish();
-                tracer.scopeManager().activate(parentSpan);
             });
         }
     }

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
@@ -74,6 +74,7 @@ class TracingCommandGatewayTest {
             assertEquals(1, mockSpans.size());
             assertEquals("send_MyCommand", mockSpans.get(0).operationName());
         }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
 
 
@@ -101,6 +102,7 @@ class TracingCommandGatewayTest {
             assertEquals(1, mockSpans.size());
             assertEquals("send_MyCommand", mockSpans.get(0).operationName());
         }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
 
     @Test
@@ -125,6 +127,7 @@ class TracingCommandGatewayTest {
             assertEquals(1, mockSpans.size());
             assertEquals("sendAndWait_MyCommand", mockSpans.get(0).operationName());
         }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
 
     @Test
@@ -149,6 +152,7 @@ class TracingCommandGatewayTest {
             assertEquals(1, mockSpans.size());
             assertEquals("sendAndWait_MyCommand", mockSpans.get(0).operationName());
         }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
 
     private static class MyCommand {

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingQueryGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingQueryGatewayTest.java
@@ -66,5 +66,6 @@ class TracingQueryGatewayTest {
             assertEquals(1, mockSpans.size());
             assertEquals("send_query", mockSpans.get(0).operationName());
         }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
 }


### PR DESCRIPTION
This PR removes the activation of a `parentSpan`, which should not happen.
According to @abuijze comment on #24: 

> Since the childSpan is only executed on in a Scope, there is no need to (re)activate the parent span. That is automatically done when the scope of the childSpan ended. In fact, the (re)activation of the parent span this way may cause an additional Scope to be added to the stack, which isn't properly cleared anymore.

Also added a check on Unit Tests to make sure there is no `activeSpan` at the end of the operations, which was the case before.

This PR resolves #24 .

For historic purposes, this fix was introduced before on PR #17 and the bug introduced back on PR #21 .