### PR TITLE
[#6 & #18] Added tracing for Subscription and ScatterGather queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,11 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>3.3.4.RELEASE</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <axon.version>4.2</axon.version>
+        <axon.version>4.3.1</axon.version>
 
         <spring.version>5.1.1.RELEASE</spring.version>
         <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
@@ -122,6 +122,7 @@
 
         <jackson.version>2.9.4</jackson.version>
         <commons-io.version>2.6</commons-io.version>
+        <reactor.version>3.3.4.RELEASE</reactor.version>
 
         <junit.jupiter.version>5.6.1</junit.jupiter.version>
         <mockito.version>3.3.3</mockito.version>
@@ -234,7 +235,12 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
-                <version>3.3.4.RELEASE</version>
+                <version>${reactor.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-test</artifactId>
+                <version>${reactor.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -59,6 +59,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -63,6 +63,11 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
@@ -61,7 +61,7 @@ public class SpanUtils {
         return message.getPayloadType().getSimpleName();
     }
 
-    private static String messageName(Class payloadType, String name) {
+    static String messageName(Class payloadType, String name) {
         if (!payloadType.getName().equals(name)) {
             return name;
         }

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
@@ -61,7 +61,7 @@ public class SpanUtils {
         return message.getPayloadType().getSimpleName();
     }
 
-    static String messageName(Class payloadType, String name) {
+    private static String messageName(Class payloadType, String name) {
         if (!payloadType.getName().equals(name)) {
             return name;
         }

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
@@ -7,7 +7,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.QueryMessage;
 
 /**
- * Utility class providing methods useful for attaching information to Spans.
+ * Utility class providing useful methods for attaching information to Spans.
  *
  * @author Lucas Campos
  * @since 4.0

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TraceableSubscriptionQueryResult.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TraceableSubscriptionQueryResult.java
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
  * @param <I> The type of initial result
  * @param <U> The type of incremental updates
  * @author Lucas Campos
- * @since 4.2
+ * @since 4.3
  */
 public class TraceableSubscriptionQueryResult<I, U> implements SubscriptionQueryResult<I, U> {
 
@@ -43,7 +43,7 @@ public class TraceableSubscriptionQueryResult<I, U> implements SubscriptionQuery
 
     @Override
     public Flux<U> updates() {
-        return updates.doOnEach(ignored -> span.log("updatesResultReceived"));
+        return updates.doOnEach(ignored -> span.log("updateReceived"));
     }
 
     @Override

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TraceableSubscriptionQueryResult.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TraceableSubscriptionQueryResult.java
@@ -1,0 +1,55 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.Span;
+import org.axonframework.common.Registration;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Traceable implementation of {@link SubscriptionQueryResult}.
+ *
+ * @param <I> The type of initial result
+ * @param <U> The type of incremental updates
+ * @author Lucas Campos
+ * @since 4.2
+ */
+public class TraceableSubscriptionQueryResult<I, U> implements SubscriptionQueryResult<I, U> {
+
+    private final Mono<I> initialResult;
+    private final Flux<U> updates;
+    private final Registration registrationDelegate;
+    private final Span span;
+
+    /**
+     * Initializes a Traceable SubscriptionQueryResult which contains the original subscriptionQueryResult and the
+     * responsible Span.
+     *
+     * @param subscriptionQueryResult the original subscriptionQueryResult
+     * @param span                    the span wrapping the subscriptionQuery
+     */
+    public TraceableSubscriptionQueryResult(SubscriptionQueryResult subscriptionQueryResult, Span span) {
+        this.initialResult = subscriptionQueryResult.initialResult();
+        this.updates = subscriptionQueryResult.updates();
+        this.registrationDelegate = subscriptionQueryResult;
+        this.span = span;
+    }
+
+    @Override
+    public Mono<I> initialResult() {
+        span.log("initialResultReceived");
+        return initialResult;
+    }
+
+    @Override
+    public Flux<U> updates() {
+        return updates.doOnEach(ignored -> span.log("updatesResultReceived"));
+    }
+
+    @Override
+    public boolean cancel() {
+        span.log("subscriptionClosed");
+        span.finish();
+        return registrationDelegate.cancel();
+    }
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TraceableSubscriptionQueryResultTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TraceableSubscriptionQueryResultTest.java
@@ -1,0 +1,52 @@
+package org.axonframework.extensions.tracing;
+
+import io.opentracing.Span;
+import io.opentracing.mock.MockTracer;
+import org.axonframework.queryhandling.DefaultSubscriptionQueryResult;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
+import org.junit.jupiter.api.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * Test class for the {@link DefaultSubscriptionQueryResult}.
+ *
+ * @author Lucas Campos
+ */
+class TraceableSubscriptionQueryResultTest {
+
+    private MockTracer mockTracer;
+
+    @BeforeEach
+    void before() {
+        this.mockTracer = new MockTracer();
+    }
+
+    @Test
+    void testTraceableSubscriptionQueryResult() {
+        // given
+        Mono<String> initialResult = Mono.just("initial");
+        Flux<String> updates = Flux.just("update1", "update2");
+        SubscriptionQueryResult subscriptionQueryResult =
+                new DefaultSubscriptionQueryResult<>(initialResult,
+                                                     updates,
+                                                     () -> true);
+        Span span = mockTracer.buildSpan("test").start();
+
+        // when
+        TraceableSubscriptionQueryResult traceableSubscriptionQueryResult = new TraceableSubscriptionQueryResult(
+                subscriptionQueryResult, span);
+
+        // verify
+        StepVerifier.create(traceableSubscriptionQueryResult.initialResult())
+                    .expectNext("initial")
+                    .expectComplete()
+                    .verify();
+        StepVerifier.create(traceableSubscriptionQueryResult.updates())
+                    .expectNext("update1")
+                    .expectNext("update2")
+                    .expectComplete()
+                    .verify();
+    }
+}

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingQueryGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingQueryGatewayTest.java
@@ -5,16 +5,25 @@ import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.DefaultSubscriptionQueryResult;
 import org.axonframework.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
 import org.junit.jupiter.api.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
+import static org.axonframework.messaging.responsetypes.ResponseTypes.instanceOf;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -31,7 +40,7 @@ class TracingQueryGatewayTest {
 
     private TracingQueryGateway testSubject;
 
-    private QueryResponseMessage<String> answer;
+    private QueryResponseMessage<String> answer1, answer2;
 
     @BeforeEach
     void before() {
@@ -43,20 +52,21 @@ class TracingQueryGatewayTest {
                                          .delegateQueryBus(mockQueryBus)
                                          .build();
 
-        answer = new GenericQueryResponseMessage<>("answer");
+        answer1 = new GenericQueryResponseMessage<>("answer1");
+        answer2 = new GenericQueryResponseMessage<>("answer2");
     }
 
     @Test
     void testQuery() throws ExecutionException, InterruptedException {
         //noinspection unchecked
         when(mockQueryBus.query(any(QueryMessage.class)))
-                .thenReturn(CompletableFuture.completedFuture(answer));
+                .thenReturn(CompletableFuture.completedFuture(answer1));
 
         MockSpan span = mockTracer.buildSpan("test").start();
         ScopeManager scopeManager = mockTracer.scopeManager();
         try (final Scope ignored = scopeManager.activate(span)) {
             CompletableFuture<String> query = testSubject.query("query", "Query", String.class);
-            assertEquals("answer", query.get());
+            assertEquals("answer1", query.get());
 
             // Verify the parent span is restored, and that a child span was finished.
             Span activeSpan = mockTracer.activeSpan();
@@ -67,5 +77,63 @@ class TracingQueryGatewayTest {
             assertEquals("send_query", mockSpans.get(0).operationName());
         }
         assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
+    }
+
+    @Test
+    void testScatterGather() {
+        when(mockQueryBus.scatterGather(any(QueryMessage.class), anyLong(), any()))
+                .thenReturn(Stream.of(answer1, answer2));
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        try (final Scope ignored = scopeManager.activate(span)) {
+            try (Stream<String> actual = testSubject.scatterGather("query",
+                                                                   "Query",
+                                                                   ResponseTypes.instanceOf(String.class),
+                                                                   1L,
+                                                                   TimeUnit.MILLISECONDS)) {
+                Iterator<String> iterator = actual.iterator();
+                String firstResult = iterator.next();
+                assertEquals("answer1", firstResult);
+                String secondResult = iterator.next();
+                assertEquals("answer2", secondResult);
+            }
+            // Verify the parent span is restored, and that a child span was finished.
+            Span activeSpan = mockTracer.activeSpan();
+            assertEquals(span, activeSpan);
+
+            List<MockSpan> mockSpans = mockTracer.finishedSpans();
+            assertEquals(1, mockSpans.size());
+            assertEquals("scatterGather_query", mockSpans.get(0).operationName());
+        }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
+    }
+
+    @Test
+    void testSubscriptionQuery() {
+        when(mockQueryBus.subscriptionQuery(any(), any(), anyInt()))
+                .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
+
+        MockSpan span = mockTracer.buildSpan("test").start();
+        ScopeManager scopeManager = mockTracer.scopeManager();
+        try (final Scope ignored = scopeManager.activate(span)) {
+            SubscriptionQueryResult<String, String> result = testSubject.subscriptionQuery(new MyQuery(),
+                                                                                           instanceOf(String.class),
+                                                                                           instanceOf(String.class));
+            result.cancel();
+
+            // Verify the parent span is restored, and that a child span was finished.
+            Span activeSpan = mockTracer.activeSpan();
+            assertEquals(span, activeSpan);
+
+            List<MockSpan> mockSpans = mockTracer.finishedSpans();
+            assertEquals(1, mockSpans.size());
+            assertEquals("subscriptionQuery_MyQuery", mockSpans.get(0).operationName());
+        }
+        assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
+    }
+
+    private static class MyQuery {
+
     }
 }


### PR DESCRIPTION
This PR introduces tracing support for `Subscription` and `ScatterGather` queries.

This closes #6 and closes #18.