### PR TITLE
Refactor TracingCommandGateway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,18 @@
 
         <junit.jupiter.version>5.6.1</junit.jupiter.version>
         <mockito.version>3.3.3</mockito.version>
+        <awaitility.version>4.0.2</awaitility.version>
     </properties>
 
     <dependencies>
         <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,11 +148,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
We can see that `sendWithSpan` basically accepts a certain `Runnable` that will be run within the scope of a newly created span. The problem here is that this `Runnable` is used to dispatch a command which in turn wants a callback `Runnable`.

This is what we want (pseudo-java code):
```java
parentSpan = tracer.activeSpan();
childSpan = createSpan(...);
tracedCommandCallback = (...) -> {
  //the callback is executed in some other thread some time in the future,    
  //so we need to activate the span separately
  try(tracer.activate(childSpan)){
    try {
      thisSpan.log("result received");
      originalCallback.onResult(...);
      thisSpan.log("callbacks finished");
    } finally {
      thisSpan.finish();// not sure if "try-finally" is justified
    }
  }
};

try(tracer.activate(childSpan)){
  delegate.sendCommand(command, commandCallback);
  thisSpan.log("command has been dispatched");
}
```

The code that's currently in the command gateway is too confusing, so, I decided to provide a refactoring I did a while ago in #15.

I created multiple commits, so it's easier to follow.