### PR TITLE
[#41] Added tags for query operations and additional tests and checks

### DIFF
--- a/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/SpanUtils.java
@@ -39,6 +39,24 @@ public class SpanUtils {
     private static final String TAG_AXON_PAYLOAD_TYPE = "axon.message.payloadType";
     private static final String TAG_AXON_MESSAGE_NAME = "axon.message.messageName";
 
+
+    /**
+     * Registers query-specific tags to the given {@code spanBuilder} based on the given {@code query}.
+     *
+     * @param spanBuilder the Span Builder to register the tags with
+     * @param query       the query to retrieve details from
+     * @param queryName   the name provided by the {@link org.axonframework.queryhandling.QueryGateway} caller
+     * @return a builder with tags attached
+     */
+    public static Tracer.SpanBuilder withQueryMessageTags(Tracer.SpanBuilder spanBuilder,
+                                                          Message<?> query,
+                                                          String queryName) {
+        return spanBuilder.withTag(TAG_AXON_ID, query.getIdentifier())
+                          .withTag(TAG_AXON_MESSAGE_TYPE, "QueryMessage")
+                          .withTag(TAG_AXON_PAYLOAD_TYPE, resolveType(query))
+                          .withTag(TAG_AXON_MESSAGE_NAME, queryName);
+    }
+
     /**
      * Registers message-specific tags to the given {@code spanBuilder} based on the given {@code message}.
      *

--- a/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/TracingQueryGateway.java
@@ -18,8 +18,11 @@ package org.axonframework.extensions.tracing;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.responsetypes.ResponseType;
 import org.axonframework.queryhandling.DefaultQueryGateway;
@@ -34,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.extensions.tracing.SpanUtils.withQueryMessageTags;
 
 /**
  * A tracing {@link QueryGateway} which activates a calling {@link Span}, when the {@link CompletableFuture} completes.
@@ -85,12 +89,14 @@ public class TracingQueryGateway implements QueryGateway {
 
     @Override
     public <R, Q> CompletableFuture<R> query(String queryName, Q query, ResponseType<R> responseType) {
-        return getWithSpan("query_" + SpanUtils.messageName(query.getClass(), queryName), (childSpan) ->
-                delegate.query(queryName, query, responseType)
-                        .whenComplete((r, e) -> {
-                            childSpan.log("resultReceived");
-                            childSpan.finish();
-                        }));
+        return getWithSpan("query_" + SpanUtils.messageName(query.getClass(), queryName),
+                           GenericMessage.asMessage(query),
+                           queryName,
+                           (childSpan) -> delegate.query(queryName, query, responseType)
+                                                  .whenComplete((r, e) -> {
+                                                      childSpan.log("resultReceived");
+                                                      childSpan.finish();
+                                                  }));
     }
 
     @Override
@@ -99,12 +105,14 @@ public class TracingQueryGateway implements QueryGateway {
                                           ResponseType<R> responseType,
                                           long timeout,
                                           TimeUnit timeUnit) {
-        return getWithSpan("scatterGather_" + SpanUtils.messageName(query.getClass(), queryName), (childSpan) ->
-                delegate.scatterGather(queryName, query, responseType, timeout, timeUnit)
-                        .onClose(() -> {
-                            childSpan.log("resultReceived");
-                            childSpan.finish();
-                        }));
+        return getWithSpan("scatterGather_" + SpanUtils.messageName(query.getClass(), queryName),
+                           GenericMessage.asMessage(query),
+                           queryName,
+                           (childSpan) -> delegate.scatterGather(queryName, query, responseType, timeout, timeUnit)
+                                                  .onClose(() -> {
+                                                      childSpan.log("resultReceived");
+                                                      childSpan.finish();
+                                                  }));
     }
 
     @Override
@@ -114,8 +122,9 @@ public class TracingQueryGateway implements QueryGateway {
                                                                      ResponseType<U> updateResponseType,
                                                                      SubscriptionQueryBackpressure backpressure,
                                                                      int updateBufferSize) {
-
         return getWithSpan("subscriptionQuery_" + SpanUtils.messageName(query.getClass(), queryName),
+                           GenericMessage.asMessage(query),
+                           queryName,
                            (childSpan) -> new TraceableSubscriptionQueryResult<>(
                                    delegate.subscriptionQuery(
                                            queryName,
@@ -128,9 +137,10 @@ public class TracingQueryGateway implements QueryGateway {
                            ));
     }
 
-    private <T> T getWithSpan(String operation, SpanSupplier<T> supplier) {
-        Span childSpan = tracer.buildSpan(operation)
-                               .start();
+    private <T> T getWithSpan(String operation, Message query, String queryName, SpanSupplier<T> supplier) {
+        Tracer.SpanBuilder spanBuilder = withQueryMessageTags(tracer.buildSpan(operation), query, queryName)
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+        final Span childSpan = spanBuilder.start();
         try (Scope ignored = tracer.activateSpan(childSpan)) {
             return supplier.get(childSpan);
         }

--- a/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
+++ b/tracing/src/test/java/org/axonframework/extensions/tracing/TracingCommandGatewayTest.java
@@ -89,6 +89,10 @@ class TracingCommandGatewayTest {
             List<MockSpan> mockSpans = mockTracer.finishedSpans();
             assertEquals(1, mockSpans.size());
             assertEquals("send_MyCommand", mockSpans.get(0).operationName());
+            assertNotNull(mockSpans.get(0).logEntries());
+            assertFalse(mockSpans.get(0).logEntries().isEmpty());
+            assertNotNull(mockSpans.get(0).tags());
+            assertFalse(mockSpans.get(0).tags().isEmpty());
         }
         assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
@@ -117,6 +121,10 @@ class TracingCommandGatewayTest {
             List<MockSpan> mockSpans = mockTracer.finishedSpans();
             assertEquals(1, mockSpans.size());
             assertEquals("send_MyCommand", mockSpans.get(0).operationName());
+            assertNotNull(mockSpans.get(0).logEntries());
+            assertFalse(mockSpans.get(0).logEntries().isEmpty());
+            assertNotNull(mockSpans.get(0).tags());
+            assertFalse(mockSpans.get(0).tags().isEmpty());
         }
         assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
@@ -142,6 +150,10 @@ class TracingCommandGatewayTest {
             List<MockSpan> mockSpans = mockTracer.finishedSpans();
             assertEquals(1, mockSpans.size());
             assertEquals("sendAndWait_MyCommand", mockSpans.get(0).operationName());
+            assertNotNull(mockSpans.get(0).logEntries());
+            assertFalse(mockSpans.get(0).logEntries().isEmpty());
+            assertNotNull(mockSpans.get(0).tags());
+            assertFalse(mockSpans.get(0).tags().isEmpty());
         }
         assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }
@@ -167,6 +179,10 @@ class TracingCommandGatewayTest {
             List<MockSpan> mockSpans = mockTracer.finishedSpans();
             assertEquals(1, mockSpans.size());
             assertEquals("sendAndWait_MyCommand", mockSpans.get(0).operationName());
+            assertNotNull(mockSpans.get(0).logEntries());
+            assertFalse(mockSpans.get(0).logEntries().isEmpty());
+            assertNotNull(mockSpans.get(0).tags());
+            assertFalse(mockSpans.get(0).tags().isEmpty());
         }
         assertNull(scopeManager.activeSpan(), "There should be no activeSpan");
     }


### PR DESCRIPTION
The point of this PR was to play along with #41.
In the meantime, we find out tags were missing for query operations and they were added as well.
Also, additional useful checks on "all" other tests were done.

To be sure it is working, I've added an additional test for `subscriptionQuery` operation.
I've also played a bit with delayed responses in 2 forms:

- `doAnswer(new AnswersWithDelay(5000, new Returns(subscriptionQueryResult)))
                .when(mockQueryBus).subscriptionQuery(any(), any(), anyInt());`
- `updates.delayElements(Duration.ofSeconds(5))`

I haven't left it this way to not make our tests slow for no reason but you can play with this as well and see it works.

This PR resolves #41.