### PR TITLE
[#53] Add disable tracing property in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information on anything Axon, please visit our website, [http://axoniq.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io) chapter to cover this extension is currently work in progress.
+The [reference guide](https://docs.axoniq.io/reference-guide/extensions/tracing) chapter about tracing extension contains some useful information that can help you to quick start.
 
 ## Receiving help
 

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,11 +42,14 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Christophe Bouhier
  * @author Steven van Beelen
+ * @author Corrado Musumeci
  * @since 4.0
  */
 @Configuration
 @AutoConfigureAfter(EventProcessingAutoConfiguration.class)
+@EnableConfigurationProperties(TracingExtensionProperties.class)
 @ConditionalOnClass(io.opentracing.Tracer.class)
+@ConditionalOnProperty(value = "axon.extension.tracing.enabled", matchIfMissing = true)
 public class TracingAutoConfiguration {
 
     @Bean

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingExtensionProperties.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingExtensionProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author Corrado Musumeci
+ * @since 4.4
+ */
+
+package org.axonframework.extensions.tracing.autoconfig;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Defines the properties for the Tracing extension, when automatically configured in the Application Context.
+ */
+@ConfigurationProperties(prefix = "axon.extension.tracing")
+public class TracingExtensionProperties {
+
+    /**
+     * Enables Tracing configuration for this application.
+     */
+    private boolean enabled = false;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingExtensionProperties.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingExtensionProperties.java
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-/**
- * @author Corrado Musumeci
- * @since 4.4
- */
-
 package org.axonframework.extensions.tracing.autoconfig;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Defines the properties for the Tracing extension, when automatically configured in the Application Context.
+ *
+ * @author Corrado Musumeci
+ * @since 4.4
  */
+
 @ConfigurationProperties(prefix = "axon.extension.tracing")
 public class TracingExtensionProperties {
 
     /**
-     * Enables Tracing configuration for this application.
+     * Enables Tracing configuration for this application. By default tracing extension is ENABLED (enabled = true).
      */
     private boolean enabled = false;
 

--- a/tracing-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/tracing/autoconfig/AxonAutoConfigurationWithoutTracingTest.java
+++ b/tracing-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/tracing/autoconfig/AxonAutoConfigurationWithoutTracingTest.java
@@ -1,0 +1,54 @@
+package org.axonframework.extensions.tracing.autoconfig;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.extensions.tracing.TracingCommandGateway;
+import org.axonframework.extensions.tracing.TracingQueryGateway;
+import org.axonframework.queryhandling.DefaultQueryGateway;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableAutoConfiguration(exclude = {
+        JmxAutoConfiguration.class,
+        WebClientAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        DataSourceAutoConfiguration.class,
+        AxonServerAutoConfiguration.class
+})
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(properties = {
+        "axon.extension.tracing.enabled=false",
+        "opentracing.jaeger.enabled=true"})
+class AxonAutoConfigurationWithoutTracingTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private QueryGateway queryGateway;
+
+    @Autowired
+    private CommandGateway commandGateway;
+
+    @Test
+    void testContextInitialization() {
+        assertNotNull(applicationContext);
+        assertFalse(queryGateway instanceof TracingQueryGateway);
+        assertFalse(commandGateway instanceof TracingCommandGateway);
+        assertTrue(queryGateway instanceof DefaultQueryGateway);
+        assertTrue(commandGateway instanceof DefaultCommandGateway);
+    }
+}


### PR DESCRIPTION
This PR solves issue #53 

Tracing can now be disabled through the property `axon.extension.tracing.enabled`, `true` by default.