### PR TITLE
Added automatic release notes generation on milestone closure

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,20 @@
+releasenotes:
+  sections:
+    - title: "Features"
+      emoji: ":star:"
+      labels: [ "Type: Feature" ]
+    - title: "Enhancements"
+      emoji: ":chart_with_upwards_trend:"
+      labels: [ "Type: Enhancement" ]
+    - title: "Bug Fixes"
+      emoji: ":beetle:"
+      labels: [ "Type: Bug" ]
+    - title: "Dependency Upgrade"
+      emoji: ":hammer_and_wrench:"
+      labels: [ "Type: Dependency Upgrade" ]
+  issues:
+    exclude:
+      labels: [ "Type: Incorrect Repository", "Type: Question" ]
+  contributors:
+    exclude:
+      names: [ "dependabot" ]

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,33 @@
+# Trigger the workflow on milestone events
+on: 
+  milestone:
+    types: [closed]
+name: Milestone Closure
+jobs:
+  create-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Create Release Notes Markdown
+      uses: docker://decathlon/release-notes-generator-action:2.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        OUTPUT_FOLDER: temp_release_notes
+        USE_MILESTONE_TITLE: "true"
+    - name: Get the name of the created Release Notes file and extract Version
+      run: |
+        RELEASE_NOTES_FILE=$(ls temp_release_notes/*.md | head -n 1)
+        echo "RELEASE_NOTES_FILE=$RELEASE_NOTES_FILE" >> $GITHUB_ENV
+        VERSION="v"
+        VERSION+=$(echo ${{ github.event.milestone.title }} | cut -d' ' -f2)
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+    - name: Create a Draft Release Notes on GitHub
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ env.VERSION }}
+        release_name:  ${{ github.event.repository.name }} ${{ env.VERSION }}
+        body_path: ${{ env.RELEASE_NOTES_FILE }}
+        draft: true


### PR DESCRIPTION
The goal of this automation is to create a release notes as soon as we close a Milestone.

The release notes is created using the [release-notes-generator-action](https://github.com/Decathlon/release-notes-generator-action) from Decathlon paired with the [create-release](https://github.com/actions/create-release) default action from GitHub.