### PR TITLE
Removing unnecessary span build by using orElseGet instead of orElse

### DIFF
--- a/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
+++ b/tracing/src/main/java/org/axonframework/extensions/tracing/OpenTraceHandlerInterceptor.java
@@ -94,7 +94,7 @@ public class OpenTraceHandlerInterceptor implements MessageHandlerInterceptor<Me
 
         Tracer.SpanBuilder spanBuilder = getParentSpan(message)
                 .map(parentSpan -> tracer.buildSpan(operationName).asChildOf(parentSpan))
-                .orElse(tracer.buildSpan(operationName));
+                .orElseGet(() -> tracer.buildSpan(operationName));
 
         final Span span = messageTagBuilderService.withMessageTags(spanBuilder, unitOfWork.getMessage())
                                                   .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)


### PR DESCRIPTION
This PR removes unnecessary call to `tracer.buildSpan` in `OpenTraceHandlerInterceptor` when parent span exists