### PR TITLE
Change how Sonar is invoked for GHAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,25 +40,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven
 
-      - name: Maven operation with Sonar
+      - name: Regular Build
+        run: |
+          ./mvnw -B -U clean verify
+
+      - name: Sonar Analysis
         if: matrix.sonar-enabled
         run: |
-          mvn -B -U -Pcoverage \
-          clean verify \
-          sonar:sonar \
+          ./mvnw -B -Pcoverage sonar:sonar \
           -Dsonar.projectKey=AxonFramework_extension-tracing \
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Maven operation without Sonar
-        if: matrix.sonar-enabled != true
-        run: |
-          mvn -B -U clean verify
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Sonatype
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,8 @@ jobs:
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Sonatype
         if: success()

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -14,6 +14,7 @@ jobs:
             sonar-enabled: false
           - java-version: 11
             sonar-enabled: true
+      fail-fast: false
 
     steps:
       - name: Checkout code
@@ -36,22 +37,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven
 
-      - name: Maven operation with Sonar
-        if: matrix.sonar-enabled
+      - name: Regular Build
         run: |
-          mvn -B -U -Pcoverage \
-          clean verify \
-          sonar:sonar \
+          ./mvnw -B -U clean verify
+
+      - name: Sonar Analysis
+        if: ${{ success() && matrix.sonar-enabled && github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          ./mvnw -B -Pcoverage sonar:sonar \
           -Dsonar.projectKey=AxonFramework_extension-tracing \
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Maven operation without Sonar
-        if: matrix.sonar-enabled != true
-        run: |
-          mvn -B -U clean verify
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -49,3 +49,5 @@ jobs:
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adjusts both the `main` and the `pullrequest` workflows on how to deal with Sonar.
Firstly, Sonar analysis is moved to a separate stage instead of being a part of the regular build.

Secondly, for pull requests, Sonar analysis should only be ran for non-forked pull requests.
This is required as SonarCloud doesn't provide a preview approach and thus needs Sonar's secrets; secrets that we don't want to share with non-team members.