### PR TITLE
Add support for Spring boot 3 autoconfiguration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
           - java-version: 8
             sonar-enabled: false
           - java-version: 11
+            sonar-enabled: false
+          - java-version: 17
             sonar-enabled: true
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,8 +13,10 @@ jobs:
           - java-version: 8
             sonar-enabled: false
           - java-version: 11
+            sonar-enabled: false
+          - java-version: 17
             sonar-enabled: true
-      fail-fast: false # run both to the end
+      fail-fast: false # run all to the end
 
     steps:
       - name: Checkout code

--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,16 @@
             </build>
         </profile>
 
+        <profile>
+            <id>java17-modules</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>tracing-spring-boot-3-integrationtests</module>
+            </modules>
+        </profile>
+
     </profiles>
 
     <repositories>

--- a/tracing-spring-boot-3-integrationtests/pom.xml
+++ b/tracing-spring-boot-3-integrationtests/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2023. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.0.2</version>
+        <relativePath/>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>axon-tracing-spring-boot-3-integrationtests</artifactId>
+    <groupId>org.axonframework.extensions.tracing</groupId>
+
+    <name>Axon Framework Tracing Extension Spring Boot 3 Integration Tests</name>
+    <description>
+        Module used to test the integration with Spring Boot 3
+    </description>
+    <version>4.7.0-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <opentracing-jaeger.version>3.3.1</opentracing-jaeger.version>
+
+        <jar-plugin.version>3.3.0</jar-plugin.version>
+        <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.axonframework.extensions.tracing</groupId>
+            <artifactId>axon-tracing-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+            <version>${opentracing-jaeger.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <encoding>UTF-8</encoding>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <repositories>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/tracing-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/jgroups/integration/TracingIntegrationTest.java
+++ b/tracing-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/jgroups/integration/TracingIntegrationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.jgroups.integration;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.metrics.Metrics;
+import io.jaegertracing.internal.metrics.NoopMetricsFactory;
+import io.jaegertracing.internal.reporters.CompositeReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.jaegertracing.spi.MetricsFactory;
+import io.jaegertracing.spi.Reporter;
+import io.jaegertracing.spi.Sampler;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.java.spring.jaeger.starter.JaegerConfigurationProperties;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.extensions.tracing.TracingCommandGateway;
+import org.axonframework.extensions.tracing.TracingQueryGateway;
+import org.axonframework.queryhandling.QueryGateway;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The {@code @EnableConfigurationProperties} and the beans set in {@link DefaultContext} are needed since the
+ * {@code opentracing-spring-jaeger-web-starter} is not yet Spring Boot 3 compliant.
+ */
+class TracingIntegrationTest {
+
+    private ApplicationContextRunner testApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        testApplicationContext = new ApplicationContextRunner()
+                .withPropertyValues("axon.axonserver.enabled=false")
+                .withUserConfiguration(DefaultContext.class);
+    }
+
+    @Test
+    void queryGatewayIsTracing() {
+        testApplicationContext
+                .run(context -> {
+                    QueryGateway queryGateway = context.getBean(QueryGateway.class);
+                    assertNotNull(queryGateway);
+                    assertTrue(queryGateway instanceof TracingQueryGateway);
+                });
+    }
+
+    @Test
+    void commandGatewayIsTracing() {
+        testApplicationContext
+                .run(context -> {
+                    CommandGateway commandGateway = context.getBean(CommandGateway.class);
+                    assertNotNull(commandGateway);
+                    assertTrue(commandGateway instanceof TracingCommandGateway);
+                });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    @EnableConfigurationProperties({JaegerConfigurationProperties.class})
+    public static class DefaultContext {
+
+        @Bean
+        public Tracer tracer(Sampler sampler, Reporter reporter, Metrics metrics,
+                             JaegerConfigurationProperties properties) {
+            JaegerTracer.Builder builder = (
+                    new JaegerTracer.Builder(properties.getServiceName()))
+                    .withReporter(reporter)
+                    .withSampler(sampler)
+                    .withTags(properties.determineTags())
+                    .withMetrics(metrics);
+            return builder.build();
+        }
+
+        @Bean
+        public Reporter reporter() {
+            List<Reporter> reporters = new LinkedList();
+            return new CompositeReporter((Reporter[]) reporters.toArray(new Reporter[reporters.size()]));
+        }
+
+        @Bean
+        public Metrics metrics(MetricsFactory metricsFactory) {
+            return new Metrics(metricsFactory);
+        }
+
+        @Bean
+        public MetricsFactory metricsFactory() {
+            return new NoopMetricsFactory();
+        }
+
+        @Bean
+        public Sampler sampler() {
+            return new ConstSampler(true);
+        }
+    }
+}

--- a/tracing-spring-boot-3-integrationtests/src/test/resources/logback-test.xml
+++ b/tracing-spring-boot-3-integrationtests/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (c) 2010-2023. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>

--- a/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
+++ b/tracing-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/tracing/autoconfig/TracingAutoConfiguration.java
@@ -18,9 +18,7 @@ package org.axonframework.extensions.tracing.autoconfig;
 import io.opentracing.Tracer;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
-import org.axonframework.config.Configurer;
 import org.axonframework.config.ConfigurerModule;
-import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.extensions.tracing.MessageTagBuilderService;
 import org.axonframework.extensions.tracing.OpenTraceDispatchInterceptor;
 import org.axonframework.extensions.tracing.OpenTraceHandlerInterceptor;
@@ -32,14 +30,13 @@ import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.springboot.autoconfig.EventProcessingAutoConfiguration;
 import org.axonframework.springboot.autoconfig.InfraConfiguration;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Auto configuration defining all required beans to allow a {@link Tracer} to be used on Axon's messaging
@@ -51,7 +48,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Lucas Campos
  * @since 4.0
  */
-@Configuration
+@AutoConfiguration
 @AutoConfigureAfter(EventProcessingAutoConfiguration.class)
 @AutoConfigureBefore(InfraConfiguration.class)
 @EnableConfigurationProperties(value = {TracingExtensionProperties.class, SpanProperties.class})

--- a/tracing-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tracing-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.axonframework.extensions.tracing.autoconfig.TracingAutoConfiguration


### PR DESCRIPTION
Also adds a module to test with Spring Boot 3, unfortunately, I could not find a Spring Boot 3 starter supplying the `Tracer`, so the test contains some auto wiring to work around that.
It also adds a Java 17 job, and switches to using that one for Sonar.