### PR TITLE
Move old docs 2 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ For more information on anything Axon, please visit our website, [http://axoniq.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io/reference-guide/extensions/tracing) chapter about tracing extension contains some useful information that can help you to quick start.
+The [AxonIQ Library](https://library.axoniq.io) contains a section for the guides of all the Axon Framework extensions.
+The Spring AOT extension guide can be found [here](https://library.axoniq.io/home/guides/axon-framework.html).
 
 ## Receiving help
 
@@ -32,10 +33,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/) should be your first stop,
- as the majority of possible scenarios you might encounter when using Axon should be covered there.
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
+  as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
- we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us. 
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently answer your question.
 Axon Framework and Server developers will help out on a best effort basis.
 Know that any support from contributors on posted question is very much appreciated on the forum.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.vscode
+vale
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,23 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: Tracing Extension docs PREVIEW
+  start_page: tracing_extension_guide::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.10/ui-bundle.zip

--- a/docs/extension-guide/antora.yml
+++ b/docs/extension-guide/antora.yml
@@ -1,0 +1,14 @@
+name: tracing_extension_guide
+title: Tracing Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The Tracing Extension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/extension-guide/modules/ROOT/pages/config.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/config.adoc
@@ -1,0 +1,15 @@
+:navtitle: Configuring the Extension
+= Configuring the Extension
+
+The extension can be disabled setting the property `axon.extension.tracing.enabled` to `false` (default=`true`). This will give you the possibility to turn it off when needed (for example, for a certain environment).
+
+Furthermore, there is a more fine-grained configuration option of the tracing span tags on commands, events and queries. You can customize span tags easily, mixing and matching between available tag `MESSAGE_ID`, `AGGREGATE_ID`, `MESSAGE_TYPE`, `PAYLOAD_TYPE`, `MESSAGE_NAME` and `PAYLOAD`. Take into account that some of the tags make sense on a certain span type, but not on another, and some of them have an hidden cost on network (such as payload). Use them wisely.
+
+[sources,properties]
+----
+axon.extension.tracing.span.commandTags=MESSAGE_ID, MESSAGE_TYPE, PAYLOAD_TYPE, MESSAGE_NAME
+axon.extension.tracing.span.eventTags=MESSAGE_ID, AGGREGATE_ID, MESSAGE_TYPE, PAYLOAD_TYPE
+axon.extension.tracing.span.queryTags=MESSAGE_ID, MESSAGE_TYPE, PAYLOAD_TYPE, MESSAGE_NAME
+----
+
+Above an example of the default value. Available tags field are listed in link:https://github.com/AxonFramework/extension-tracing/blob/master/tracing/src/main/java/org/axonframework/extensions/tracing/MessageTag.java[MessageTag.java,window=_blank,role=external] class.

--- a/docs/extension-guide/modules/ROOT/pages/index.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,27 @@
+:navtitle: Tracing
+= Tracing
+
+This extension provides functionality to trace command, event and query messages flowing through an Axon application by providing a specific implementation of the `CommandGateway`, `QueryGateway`, `MessageDispatchInterceptor` and `MessageHandlerInterceptor`. The link:https://opentracing.io/[Open Tracing,window=_blank,role=external] standard is used to provide tracing capabilities, which thus allows usage of several Open Tracing implementations.
+
+With this instrumentation, we can chain synchronous and asynchronous commands and queries, all belonging to the same parent span. A request can be visualized and analysed across Axon clients, command handlers, query handlers and event handlers, when running together or decomposed and deployed as separate parts (distributed).
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.axonframework.extensions.tracing</groupId>
+  <artifactId>axon-tracing-spring-boot-starter</artifactId>
+  <version>4.4</version>
+</dependency>
+
+<dependency>
+  <groupId>io.opentracing.contrib</groupId>
+  <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+  <version>3.2.2</version>
+</dependency>
+----
+
+The first dependency is xref:axon_framework_old_ref:ROOT:modules#_axon_tracing_spring_boot_starter[Spring Boot starter for Axon Tracing extension], which is the quickest start in to an extension configuration.
+
+The second dependency is https://www.jaegertracing.io/[Jaeger,window=_blank,role=external] implementation for OpenTracing.
+
+There are other supported tracers that can be used: LightStep, Instana, Apache SkyWalking, Datadog, Wavefront by VMware, Elastic APM and many more.

--- a/docs/extension-guide/modules/nav.adoc
+++ b/docs/extension-guide/modules/nav.adoc
@@ -1,0 +1,2 @@
+* xref::index.adoc[]
+** xref::config.adoc[]


### PR DESCRIPTION
Contents from the Extensions section for Tracing in the old reference guide have been moved here in order to allow antora to publish it as an Extension Guide in library.axoniq.io > Guides > Axon Framework